### PR TITLE
Updated listener to allow restarting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ Temporary Items
 # End of https://www.toptal.com/developers/gitignore/api/macos,jupyternotebooks
 parameters.yaml
 raw_tweets.json
+archived/Untitled.ipynb
+archived/raw_tweets_maga.json
+archived/raw_tweets_ExposeBillGates.json
+archived/functions.py
+archived/application.py

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ Temporary Items
 .apdisk
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,jupyternotebooks
+parameters.yaml
+raw_tweets.json

--- a/listener.py
+++ b/listener.py
@@ -15,6 +15,8 @@ access_token_secret = parameters['access_token_secret']
 tweet_batch_size = parameters['tweet_batch_size']
 tweet_buffer_size = parameters['tweet_buffer_size']
 tracker = parameters['tracker']
+restart_listener = parameters['restart_listener']
+restart_file = parameters['restart_file']
 
 # Connect to API
 # TODO: Streamer can still run into limiting.
@@ -26,8 +28,16 @@ api = tw.API(auth, wait_on_rate_limit=True, wait_on_rate_limit_notify=False)
 # Buffer some number of tweets in a lit
 # Dump buffered tweets into an extended list
 # Once extended list exceeds batch limit, drop it by size of buffer
+
 tweet_buffer=[]      # Create a list that will hold tweets
-raw_tweets=[]
+if restart_listener == 1:
+    with open(restart_file) as json_data:
+        d = json.load(json_data)
+        json_data.close()
+    raw_tweets=list(d)
+else:
+    raw_tweets=[]
+    
 #N=1000       # Set a number of tweets to collect before dumping into a file
 class listener(StreamListener):
     def on_data(self,data):      # triggered when data appears

--- a/parameters_example.yaml
+++ b/parameters_example.yaml
@@ -11,4 +11,7 @@ tweet_buffer_size: 200
 connected_components: 4
 k_cores: 4
 
+restart_listener: 1
+restart_file: 'raw_tweets.json'
+
 tracker: ['SpongeBob']

--- a/parameters_example.yaml
+++ b/parameters_example.yaml
@@ -11,4 +11,4 @@ tweet_buffer_size: 200
 connected_components: 4
 k_cores: 4
 
-tracker: ['BlackLivesMatter']
+tracker: ['SpongeBob']


### PR DESCRIPTION
Users can specify if run is a restart by setting 'restart_listener' to 1 and 'restart_file' to the json dump file path in parameters.yaml.